### PR TITLE
fix: remove legacy unstable oss.sonatype.org repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-*
+- Remove legacy unstable oss.sonatype.org repositories to prevent 504 gateway timeouts during dependency resolution
 
 ### Features
 

--- a/gradle/repositories/build.gradle
+++ b/gradle/repositories/build.gradle
@@ -1,5 +1,5 @@
 repositories {
     mavenCentral()
-    maven { url = 'https://oss.sonatype.org/content/repositories/releases/' }
-    maven { url = 'https://oss.sonatype.org/content/repositories/snapshots/' }
+    maven { url = 'https://central.sonatype.com/repository/maven-snapshots/' }
 }
+


### PR DESCRIPTION
The `oss.sonatype.org` legacy Nexus staging repositories are deprecated and unstable, returning `504 Gateway Time-out` responses instead of a clean `404`. Since Gradle only falls back to the next repository on a 404 (not on a 504), this blocks dependency resolution entirely when artifacts are actually available from other repositories.

This PR removes the two legacy `oss.sonatype.org` entries:
- `oss.sonatype.org/content/repositories/releases/` → covered by `mavenCentral()`
- `oss.sonatype.org/content/repositories/snapshots/` → replaced with `https://central.sonatype.com/repository/maven-snapshots/`

This aligns with the fix applied to `web3j-build-tools` and other repos in the LFDT-web3j org.